### PR TITLE
use little-endian pack codes

### DIFF
--- a/lib/wavefile.rb
+++ b/lib/wavefile.rb
@@ -25,7 +25,7 @@ module WaveFile
                :sample       => "smpl",
                :instrument   => "inst" }    # :nodoc:
 
-  PACK_CODES = {:pcm => {8 => "C*", 16 => "s*", 24 => "C*", 32 => "l*"},
+  PACK_CODES = {:pcm => {8 => "C*", 16 => "s<*", 24 => "C*", 32 => "l<*"},
                 :float => { 32 => "e*", 64 => "E*"}}    # :nodoc:
 
   UNSIGNED_INT_16 = "v"    # :nodoc:

--- a/lib/wavefile/writer.rb
+++ b/lib/wavefile/writer.rb
@@ -76,7 +76,7 @@ module WaveFile
 
       if @format.bits_per_sample == 24 && @format.sample_format == :pcm
         samples.flatten.each do |sample|
-          @file.syswrite([sample].pack("lX"))
+          @file.syswrite([sample].pack("l<X"))
         end
       else
         @file.syswrite(samples.flatten.pack(@pack_code))


### PR DESCRIPTION
Hi Joel,

the wavefile gem uses pack codes for "native endian", but it should use "little endian" for RIFF files instead.

After packaging the gem for Debian, it turned out that software using the gem didn't work properly when running on big-endian hardware.

Changing the pack codes fixes the gem and `rake test` is happy again. Tested on x86 (little endian) and powerpc (big endian).