### PR TITLE
MiniTest::Unit::TestCase is now Minitest::Test.

### DIFF
--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class BufferTest < MiniTest::Unit::TestCase
+class BufferTest < MiniTest::Test
   def test_convert
     old_format = Format.new(:mono, :pcm_16, 44100)
     new_format = Format.new(:stereo, :pcm_16, 22050)

--- a/test/duration_test.rb
+++ b/test/duration_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class DurationTest < MiniTest::Unit::TestCase
+class DurationTest < MiniTest::Test
   SECONDS_IN_MINUTE = 60
   SECONDS_IN_HOUR = SECONDS_IN_MINUTE * 60
 

--- a/test/format_test.rb
+++ b/test/format_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class FormatTest < MiniTest::Unit::TestCase
+class FormatTest < MiniTest::Test
   def test_valid_channels
     [1, 2, 3, 4, 65535].each do |valid_channels|
       assert_equal(valid_channels, Format.new(valid_channels, :pcm_16, 44100).channels)

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -4,7 +4,7 @@ require 'wavefile_io_test_helper.rb'
 
 include WaveFile
 
-class ReaderTest < MiniTest::Unit::TestCase
+class ReaderTest < MiniTest::Test
   include WaveFileIOTestHelper
 
   FIXTURE_ROOT_PATH = "test/fixtures"

--- a/test/unvalidated_format_test.rb
+++ b/test/unvalidated_format_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class UnvalidatedFormatTest < MiniTest::Unit::TestCase
+class UnvalidatedFormatTest < MiniTest::Test
   def test_initialize
     format = UnvalidatedFormat.new({:audio_format => 1,
                                     :channels => 2,

--- a/test/writer_test.rb
+++ b/test/writer_test.rb
@@ -4,7 +4,7 @@ require 'wavefile_io_test_helper.rb'
 
 include WaveFile
 
-class WriterTest < MiniTest::Unit::TestCase
+class WriterTest < MiniTest::Test
   include WaveFileIOTestHelper
 
   OUTPUT_FOLDER = "test/fixtures/actual_output"


### PR DESCRIPTION
Testing version 0.7.0 resulted in the complaint

`MiniTest::Unit::TestCase is now Minitest::Test.`