### PR TITLE
Upgrading to the latest version of MiniTest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+# For development
+group :test do
+  gem 'rake'
+  gem 'minitest', '~> 5'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.8.4)
+    rake (10.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest (~> 5)
+  rake
+
+BUNDLED WITH
+   1.11.2

--- a/README.markdown
+++ b/README.markdown
@@ -91,6 +91,17 @@ First, install the WaveFile gem from rubygems.org:
 Note that if you're installing the gem into the default Ruby that comes pre-installed on MacOS (as opposed to a Ruby installed via [RVM](http://rvm.io/) or [rbenv](https://github.com/sstephenson/rbenv/)), you should used `sudo gem install wavefile`. Otherwise you might run into a file permission error.
 
 
+# Local Development
+
+First, install the required development/test dependencies:
+
+    bundle install
+
+Then, to run the tests:
+
+    bundle exec rake test
+
+
 # Contributing
 
 1. Fork my repo

--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class BufferTest < MiniTest::Unit::TestCase
+class BufferTest < Minitest::Test
   def test_convert
     old_format = Format.new(:mono, :pcm_16, 44100)
     new_format = Format.new(:stereo, :pcm_16, 22050)

--- a/test/duration_test.rb
+++ b/test/duration_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class DurationTest < MiniTest::Unit::TestCase
+class DurationTest < Minitest::Test
   SECONDS_IN_MINUTE = 60
   SECONDS_IN_HOUR = SECONDS_IN_MINUTE * 60
 

--- a/test/format_test.rb
+++ b/test/format_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class FormatTest < MiniTest::Unit::TestCase
+class FormatTest < Minitest::Test
   def test_valid_channels
     [1, 2, 3, 4, 65535].each do |valid_channels|
       assert_equal(valid_channels, Format.new(valid_channels, :pcm_16, 44100).channels)

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -4,7 +4,7 @@ require 'wavefile_io_test_helper.rb'
 
 include WaveFile
 
-class ReaderTest < MiniTest::Unit::TestCase
+class ReaderTest < Minitest::Test
   include WaveFileIOTestHelper
 
   FIXTURE_ROOT_PATH = "test/fixtures"

--- a/test/unvalidated_format_test.rb
+++ b/test/unvalidated_format_test.rb
@@ -3,7 +3,7 @@ require 'wavefile.rb'
 
 include WaveFile
 
-class UnvalidatedFormatTest < MiniTest::Unit::TestCase
+class UnvalidatedFormatTest < Minitest::Test
   def test_initialize
     format = UnvalidatedFormat.new({:audio_format => 1,
                                     :channels => 2,

--- a/test/writer_test.rb
+++ b/test/writer_test.rb
@@ -4,7 +4,7 @@ require 'wavefile_io_test_helper.rb'
 
 include WaveFile
 
-class WriterTest < MiniTest::Unit::TestCase
+class WriterTest < Minitest::Test
   include WaveFileIOTestHelper
 
   OUTPUT_FOLDER = "test/fixtures/actual_output"


### PR DESCRIPTION
This involves changing usage of `MiniTest::Unit::TestCase` into `Minitest::Test`.

Since this change will cause tests to fail on versions of Ruby 2.1 and earlier, due to them having an older version of the Minitest gem built in, this commit also introduces a Gemfile that specifies a more modern version of Minitest. This means that tests now need to be run using `bundle exec rake test`, instead of `rake test`.