### PR TITLE
Support reading from IO

### DIFF
--- a/lib/wavefile/reader.rb
+++ b/lib/wavefile/reader.rb
@@ -39,8 +39,13 @@ module WaveFile
     # Raises Errno::ENOENT if the specified file can't be found
     # Raises InvalidFormatError if the specified file isn't a valid wave file
     def initialize(file_name, format=nil)
-      @file_name = file_name
-      @file = File.open(file_name, "rb")
+      if file_name.respond_to?(:sysread)
+        @file_name = "stream"
+        @file = file_name
+      else
+        @file_name = file_name
+        @file = File.open(file_name, "rb")
+      end
 
       begin
         @riff_reader = ChunkReaders::RiffReader.new(@file, @file_name)

--- a/lib/wavefile/writer.rb
+++ b/lib/wavefile/writer.rb
@@ -26,8 +26,13 @@ module WaveFile
     #
     # If no block is given, then sample data can be written until the close method is called.
     def initialize(file_name, format)
-      @file_name = file_name
-      @file = File.open(file_name, "wb")
+      if file_name.respond_to?(:syswrite)
+        @file_name = "stream"
+        @file = file_name
+      else
+        @file_name = file_name
+        @file = File.open(file_name, "wb")
+      end
       @format = format
 
       @total_sample_frames = 0

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -179,6 +179,25 @@ class ReaderTest < Minitest::Test
     assert_equal(SQUARE_WAVE_CYCLE[:stereo][:pcm_8] * 24,  buffers[2].samples)
   end
 
+  def test_read_from_io_stream
+    reader = Reader.new(File.open(fixture("valid/valid_mono_pcm_16_44100.wav")),  Format.new(:stereo, :pcm_8, 22100))
+    buffers = []
+
+    begin
+      while true do
+        buffers << reader.read(1024)
+      end
+    rescue EOFError
+      reader.close
+    end
+
+    assert_equal(3, buffers.length)
+    assert_equal([1024, 1024, 192], buffers.map {|buffer| buffer.samples.length })
+    assert_equal(SQUARE_WAVE_CYCLE[:stereo][:pcm_8] * 128, buffers[0].samples)
+    assert_equal(SQUARE_WAVE_CYCLE[:stereo][:pcm_8] * 128, buffers[1].samples)
+    assert_equal(SQUARE_WAVE_CYCLE[:stereo][:pcm_8] * 24,  buffers[2].samples)
+  end
+
   def test_read_with_padding_byte
     buffers = read_file("valid/valid_mono_pcm_8_44100_with_padding_byte.wav", 1024)
 


### PR DESCRIPTION
Add support for reading wave file data from an IO interface instead of a filename only
