### PR TITLE
Frozen Literals - fix tests w/ frozen literals

### DIFF
--- a/lib/wavefile.rb
+++ b/lib/wavefile.rb
@@ -11,8 +11,8 @@ module WaveFile
 
   WAVEFILE_FORMAT_CODE = "WAVE"    # :nodoc:
   FORMAT_CODES = {:pcm => 1, :float => 3, :extensible => 65534}    # :nodoc:
-  SUB_FORMAT_GUID_PCM = "\x01\x00\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71".force_encoding("ASCII-8BIT")    # :nodoc:
-  SUB_FORMAT_GUID_FLOAT = "\x03\x00\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71".force_encoding("ASCII-8BIT")    # :nodoc:
+  SUB_FORMAT_GUID_PCM = String.new("\x01\x00\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71").force_encoding("ASCII-8BIT").freeze   # :nodoc:
+  SUB_FORMAT_GUID_FLOAT = String.new("\x03\x00\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71").force_encoding("ASCII-8BIT").freeze   # :nodoc:
   CHUNK_IDS = {:riff         => "RIFF",
                :format       => "fmt ",
                :data         => "data",


### PR DESCRIPTION
When frozen literals are enabled via

--enable-frozen-string-literal

The call to `String#force_encoding` fails due to it attempting to modify
a frozen literal. Instead, create the String with `String.new` so it is
mutable, modify it and then freeze it after forcing the encoding.

All tests now pass on Ruby 2.4 w/ frozen literals.